### PR TITLE
added a hidden dotenv variable for the host name

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -11,7 +11,7 @@ if (process.env.JAWSDB_URL) {
     process.env.DB_USER,
     process.env.DB_PASSWORD,
     {
-      host: 'localhost',
+      host: process.env.DB_HOST,
       dialect: 'mysql',
       port: 3306
     }


### PR DESCRIPTION
This should fix the issue of having to change host names all the time. Just make sure to add a variable called DB_HOST= "host_name_here" in your .env file